### PR TITLE
Return abspath when getting data path

### DIFF
--- a/langconv/language/__init__.py
+++ b/langconv/language/__init__.py
@@ -27,7 +27,7 @@ class Language:
 
 def get_data_file_path(filename: str) -> str:
     """Gets the path to the given data file."""
-    return os.path.join(os.path.dirname(__file__), '../data', filename)
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '../data', filename))
 
 
 __all__ = ['Language', 'get_data_file_path']


### PR DESCRIPTION
The original behavior will fail under Linux after compiling the module with nuitka:

![image](https://github.com/user-attachments/assets/95675965-66a7-4593-9051-3b1370d232ca)

